### PR TITLE
Error raised when UpperLimit / ConfidenceInterval cannot be interpolated

### DIFF
--- a/skstats/hypotests/calculators/basecalculator.py
+++ b/skstats/hypotests/calculators/basecalculator.py
@@ -222,7 +222,7 @@ class BaseCalculator(object):
             else:
                 bestfitpoi.append(POI(param, bf))
                 if len(poinull) == 1:
-                    self._obs_nll[POI(param, bf)] = self.bestfit.fmin
+                    self._obs_nll[tuple(bestfitpoi)] = self.bestfit.fmin
 
         nll_poinull_obs = self.obs_nll(poinull)
         nll_bestfitpoi_obs = self.obs_nll(bestfitpoi)

--- a/skstats/hypotests/core/confidence_interval.py
+++ b/skstats/hypotests/core/confidence_interval.py
@@ -88,13 +88,28 @@ class ConfidenceInterval(BaseTest):
         poinull = self.poinull[0]
         observed = self.calculator.bestfit.params[poinull.parameter]["value"]
 
+        if min(self.pvalues()) > alpha:
+            msg = f"The minimum of the scanned p-values is {min(self.pvalues())} which is larger than the"
+            msg += f" confidence level alpha = {alpha}. Try to increase the range of POI values."
+            raise ValueError(msg)
+
         tck = interpolate.splrep(poinull.value, self.pvalues()-alpha, s=0)
         root = interpolate.sproot(tck)
 
         bands = {}
         bands["observed"] = observed
-        bands["lower"] = root[0]
-        bands["upper"] = root[1]
+
+        if len(root) < 2:
+            msg = f" bound on the POI `{poinull.name}` cannot not be interpolated."
+            if root[0] < observed:
+                msg = "Upper" + msg + " Try to increase the maximum POI value."
+            else:
+                msg = "Low" + msg + " Try to decrease the minimum POI value."
+            raise ValueError(msg)
+
+        else:
+            bands["lower"] = root[0]
+            bands["upper"] = root[1]
 
         if printlevel > 0:
 

--- a/skstats/hypotests/core/confidence_interval.py
+++ b/skstats/hypotests/core/confidence_interval.py
@@ -1,6 +1,7 @@
 from scipy import interpolate
 
 from .basetest import BaseTest
+from ..exceptions import POIRangeError
 
 
 class ConfidenceInterval(BaseTest):
@@ -91,7 +92,7 @@ class ConfidenceInterval(BaseTest):
         if min(self.pvalues()) > alpha:
             msg = f"The minimum of the scanned p-values is {min(self.pvalues())} which is larger than the"
             msg += f" confidence level alpha = {alpha}. Try to increase the range of POI values."
-            raise ValueError(msg)
+            raise POIRangeError(msg)
 
         tck = interpolate.splrep(poinull.value, self.pvalues()-alpha, s=0)
         root = interpolate.sproot(tck)
@@ -105,7 +106,7 @@ class ConfidenceInterval(BaseTest):
                 msg = "Upper" + msg + " Try to increase the maximum POI value."
             else:
                 msg = "Low" + msg + " Try to decrease the minimum POI value."
-            raise ValueError(msg)
+            raise POIRangeError(msg)
 
         else:
             bands["lower"] = root[0]

--- a/skstats/hypotests/core/upperlimit.py
+++ b/skstats/hypotests/core/upperlimit.py
@@ -142,6 +142,11 @@ class UpperLimit(BaseTest):
                 pvalues = self.pvalues(CLs)[k]
                 values = poinull.value
 
+            if min(pvalues) > alpha:
+                msg = f"The minimum of the scanned p-values is {min(pvalues)} which is larger than the"
+                msg += f" confidence level alpha = {alpha}. Try to increase the maximum POI value."
+                raise ValueError(msg)
+
             tck = interpolate.splrep(values, pvalues-alpha, s=0)
             root = interpolate.sproot(tck)
 

--- a/skstats/hypotests/core/upperlimit.py
+++ b/skstats/hypotests/core/upperlimit.py
@@ -3,6 +3,7 @@ from scipy import interpolate
 from .basetest import BaseTest
 from ..calculators import AsymptoticCalculator
 from ..parameters import POI
+from ..exceptions import POIRangeError
 
 
 class UpperLimit(BaseTest):
@@ -145,7 +146,7 @@ class UpperLimit(BaseTest):
             if min(pvalues) > alpha:
                 msg = f"The minimum of the scanned p-values is {min(pvalues)} which is larger than the"
                 msg += f" confidence level alpha = {alpha}. Try to increase the maximum POI value."
-                raise ValueError(msg)
+                raise POIRangeError(msg)
 
             tck = interpolate.splrep(values, pvalues-alpha, s=0)
             root = interpolate.sproot(tck)

--- a/skstats/hypotests/exceptions.py
+++ b/skstats/hypotests/exceptions.py
@@ -1,0 +1,10 @@
+"""
+Specific exceptions for the `hypotests` submodule
+"""
+
+
+class POIRangeError(Exception):
+    """Exception class non adequate POI scan range"""
+
+    def __init__(self, *args, **kwargs):
+        Exception.__init__(self, *args, **kwargs)

--- a/tests/hypotests/test_confidence_intervals.py
+++ b/tests/hypotests/test_confidence_intervals.py
@@ -76,3 +76,18 @@ def test_with_asymptotic_calculator():
 
     assert interval["lower"] == pytest.approx(1.1810371356602791, rel=0.1)
     assert interval["upper"] == pytest.approx(1.2156701172321935, rel=0.1)
+
+    with pytest.raises(ValueError):
+        poinull = POI(mean, np.linspace(1.2, 1.205, 50))
+        ci = ConfidenceInterval(calculator, [poinull])
+        ci.interval()
+
+    with pytest.raises(ValueError):
+        poinull = POI(mean, np.linspace(1.2, 1.26, 50))
+        ci = ConfidenceInterval(calculator, [poinull])
+        ci.interval()
+
+    with pytest.raises(ValueError):
+        poinull = POI(mean, np.linspace(1.17, 1.205, 50))
+        ci = ConfidenceInterval(calculator, [poinull])
+        ci.interval()

--- a/tests/hypotests/test_confidence_intervals.py
+++ b/tests/hypotests/test_confidence_intervals.py
@@ -9,6 +9,7 @@ from skstats.hypotests.calculators.basecalculator import BaseCalculator
 from skstats.hypotests.calculators import AsymptoticCalculator
 from skstats.hypotests import ConfidenceInterval
 from skstats.hypotests.parameters import POI
+from skstats.hypotests.exceptions import POIRangeError
 
 
 def create_loss():
@@ -77,17 +78,17 @@ def test_with_asymptotic_calculator():
     assert interval["lower"] == pytest.approx(1.1810371356602791, rel=0.1)
     assert interval["upper"] == pytest.approx(1.2156701172321935, rel=0.1)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(POIRangeError):
         poinull = POI(mean, np.linspace(1.2, 1.205, 50))
         ci = ConfidenceInterval(calculator, [poinull])
         ci.interval()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(POIRangeError):
         poinull = POI(mean, np.linspace(1.2, 1.26, 50))
         ci = ConfidenceInterval(calculator, [poinull])
         ci.interval()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(POIRangeError):
         poinull = POI(mean, np.linspace(1.17, 1.205, 50))
         ci = ConfidenceInterval(calculator, [poinull])
         ci.interval()

--- a/tests/hypotests/test_upperlimit.py
+++ b/tests/hypotests/test_upperlimit.py
@@ -9,6 +9,7 @@ from skstats.hypotests.calculators.basecalculator import BaseCalculator
 from skstats.hypotests.calculators import AsymptoticCalculator
 from skstats.hypotests import UpperLimit
 from skstats.hypotests.parameters import POI
+from skstats.hypotests.exceptions import POIRangeError
 
 
 def create_loss():
@@ -90,7 +91,7 @@ def test_with_asymptotic_calculator():
 
     # test error when scan range is too small
 
-    with pytest.raises(ValueError):
+    with pytest.raises(POIRangeError):
         poinull = POI(Nsig, np.linspace(0.0, 12, 20))
         ul = UpperLimit(calculator, [poinull], [poialt])
         ul.upperlimit(alpha=0.05, CLs=True)

--- a/tests/hypotests/test_upperlimit.py
+++ b/tests/hypotests/test_upperlimit.py
@@ -87,3 +87,10 @@ def test_with_asymptotic_calculator():
 
     ul.upperlimit(alpha=0.05, CLs=False)
     ul_qtilde.upperlimit(alpha=0.05, CLs=True)
+
+    # test error when scan range is too small
+
+    with pytest.raises(ValueError):
+        poinull = POI(Nsig, np.linspace(0.0, 12, 20))
+        ul = UpperLimit(calculator, [poinull], [poialt])
+        ul.upperlimit(alpha=0.05, CLs=True)


### PR DESCRIPTION
I have a colleague that started to try `scikit-stats`, he encountered an obscure error when trying to compute upper limits. 
The error was a `TypeError`, due to the interpolator that couldn't find a find a point where `p-value = alpha`. So now errors are raised with a message suggesting to increase the range of scanned values for the POI.

`ValueError` are raised, but I am not convinced this is the right error type to raise (I am always confused with the built-in python exceptions ...). What do you think  @eduardo-rodrigues ?  